### PR TITLE
Fix issues arising when ApiPath contains two or more segments

### DIFF
--- a/input/Shared/_RightNavigation.cshtml
+++ b/input/Shared/_RightNavigation.cshtml
@@ -1,9 +1,12 @@
-@foreach(IDocument doc in OutputPages.GetChildrenOf("index.html")
-    .Where(x => x.GetBool(SiteKeys.ShowInNavigation, true))
-    .OrderBy(x => x.GetInt(Keys.Order)))
-{
-    // Don't add the home page to the nav bar
-    if (doc.Destination != "index.html")
+@{
+    String indexFileName = Context.Settings.GetIndexFileName();
+    foreach(IDocument doc in OutputPages.GetChildrenOf(indexFileName)
+        // Ensure the API path is added even if it's not a direct child of the root page
+        .Concat(OutputPages.Get(NormalizedPath.Combine(Context.GetPath(DocsKeys.ApiPath), indexFileName)))
+        .Where(x => x.GetBool(SiteKeys.ShowInNavigation, true))
+        // Ensure that duplicate API links aren't shown 
+        .Distinct()
+        .OrderBy(x => x.GetInt(Keys.Order)))
     {
         <li class="nav-item">
             @Html.DocumentLink(

--- a/input/_Layout.cshtml
+++ b/input/_Layout.cshtml
@@ -73,7 +73,7 @@
             }
             @await Html.PartialAsync("_Splash")
             @{
-                string section = Document.Destination.Segments.Length > 1 ? Document.Destination.Segments[0].ToString() : null;
+                string section = Document.Destination.Segments.Length > 1 ? @Context.GetString(DocsKeys.ApiPath) : null;
                 IDocument root = OutputPages.Get(section + "/index.html");
             }
             <div class="flex-grow-1 d-flex flex-column">
@@ -165,6 +165,10 @@
                                         if (IsSectionDefined(SectionNames.Sidebar))
                                         {
                                             IgnoreSection(SectionNames.Sidebar);
+                                        }
+                                        if (IsSectionDefined(SectionNames.ChildPages))
+                                        {
+                                            IgnoreSection(SectionNames.ChildPages);
                                         }
 
                                         <div id="content" class="offset-lg-2 col-12 col-lg-8 p-4 pt-md-0 bg-white">


### PR DESCRIPTION
Some issues appear when the value for ApiPath contains multiple segments, like `api/test`. Specifically, the layout would refuse to render the sidebar, which would also cause Razor to abort since the `ChildPages` section existed but wasn't rendered. Additionally, the right navigation wouldn't include a link to the API since it's not a direct child of index.html.