### PR TITLE
Show correct navigation for Markdown pages

### DIFF
--- a/input/_Layout.cshtml
+++ b/input/_Layout.cshtml
@@ -73,7 +73,9 @@
             }
             @await Html.PartialAsync("_Splash")
             @{
-                string section = Document.Destination.Segments.Length > 1 ? @Context.GetString(DocsKeys.ApiPath) : null;
+                string apiPath = Context.GetString(DocsKeys.ApiPath);
+                string section = Document.Destination.Segments.Length == 0 ? null :
+                    (new NormalizedPath(apiPath).ContainsDescendantOrSelf(Document.Destination) ? apiPath : Document.Destination.Segments[0].ToString());
                 IDocument root = OutputPages.Get(section + "/index.html");
             }
             <div class="flex-grow-1 d-flex flex-column">


### PR DESCRIPTION
https://github.com/statiqdev/Docable/commit/fe480ef0bf9c64f6c7929436b4a92d22286f731f changed the logic to determine the section that by default always only the API will be shown in the sidebar, even when a Markdown content page is shown.

This reverts back to the old behavior where the navigation for the current document is shown.

Fixes #22 